### PR TITLE
Support of multilang fields in template settings form

### DIFF
--- a/controllers/admin/AdminEmailsManager.php
+++ b/controllers/admin/AdminEmailsManager.php
@@ -45,12 +45,15 @@ class AdminEmailsManagerController extends ModuleAdminController
                 if (!isset($settings['inputs']) || !is_array($settings['inputs'])) {
                     die(Tools::displayError('Invalid template'));
                 }
-
+                
+                $id_lang = Context::getContext()->language->id;
+                $iso_lang = Context::getContext()->language->iso_code;
+                
                 foreach ($settings['inputs'] as $input) {
                     $value = Tools::getValue($input['name']);
                     if ($current['name'] == $template && isset($current['inputs'][$input['name']])) {
                         if (isset($input['lang']) && $input['lang'] == true) {
-                                $this->context->smarty->assign($input['name'], $current['inputs'][$input['name']][Context::getContext()->language->id]);
+                            $this->context->smarty->assign($input['name'], isset($current['inputs'][$input['name']][$id_lang]) ? $current['inputs'][$input['name']][$id_lang] : '');
                         } else {
                             $this->context->smarty->assign($input['name'], $current['inputs'][$input['name']]);
                         }
@@ -58,7 +61,7 @@ class AdminEmailsManagerController extends ModuleAdminController
                         $this->context->smarty->assign($input['name'], $value);
                     } else {
                         if (isset($input['lang']) && $input['lang'] == true) {
-                            $this->context->smarty->assign($input['name'], isset($input['default'][Context::getContext()->language->iso_code]) ? $input['default'][Context::getContext()->language->iso_code] : '');
+                            $this->context->smarty->assign($input['name'], isset($input['default'][$iso_lang]) ? $input['default'][$iso_lang] : '');
                         } else {
                             $this->context->smarty->assign($input['name'], $input['default']);
                         }

--- a/controllers/admin/AdminEmailsManager.php
+++ b/controllers/admin/AdminEmailsManager.php
@@ -49,7 +49,11 @@ class AdminEmailsManagerController extends ModuleAdminController
                 foreach ($settings['inputs'] as $input) {
                     $value = Tools::getValue($input['name']);
                     if ($current['name'] == $template && isset($current['inputs'][$input['name']])) {
-                        $this->context->smarty->assign($input['name'], $current['inputs'][$input['name']]);
+                        if (isset($input['lang']) && $input['lang'] == true) {
+                                $this->context->smarty->assign($input['name'], $current['inputs'][$input['name']][Context::getContext()->language->id]);
+                        } else {
+                            $this->context->smarty->assign($input['name'], $current['inputs'][$input['name']]);
+                        }
                     } elseif ($value) {
                         $this->context->smarty->assign($input['name'], $value);
                     } else {

--- a/controllers/admin/AdminEmailsManager.php
+++ b/controllers/admin/AdminEmailsManager.php
@@ -57,7 +57,11 @@ class AdminEmailsManagerController extends ModuleAdminController
                     } elseif ($value) {
                         $this->context->smarty->assign($input['name'], $value);
                     } else {
-                        $this->context->smarty->assign($input['name'], $input['default']);
+                        if (isset($input['lang']) && $input['lang'] == true) {
+                            $this->context->smarty->assign($input['name'], isset($input['default'][Context::getContext()->language->iso_code]) ? $input['default'][Context::getContext()->language->iso_code] : '');
+                        } else {
+                            $this->context->smarty->assign($input['name'], $input['default']);
+                        }
                     }
                 }
 

--- a/ps_emailsmanager.php
+++ b/ps_emailsmanager.php
@@ -224,15 +224,6 @@ class Ps_EmailsManager extends Module
 
         return $translations;
     }
-    
-    public function getLangFieldsTranslations($lang_fields, $id_lang)
-    {
-        $lang_fields_value = array();
-        foreach ($lang_fields as $field => $values) {
-            $lang_fields_value[$field] = $values[$id_lang];
-        }
-        return $lang_fields_value;
-    }
 
     public function translateTemplate($tpl, $translations)
     {
@@ -307,9 +298,8 @@ class Ps_EmailsManager extends Module
             //Fetch translations from addons api
             $translations = $this->getEmailsTranslations($language['iso_code']);
 
-            $lang_fields_value = $this->getLangFieldsTranslations($lang_fields, $language['id_lang']);
-            foreach ($lang_fields_value as $k => $v) {
-                $this->context->smarty->assign(array($k => $v));
+            foreach ($lang_fields as $field => $values) {
+                $this->context->smarty->assign(array($field => $values[$language['id_lang']]));
             }
 
             if (!$translations) {

--- a/ps_emailsmanager.php
+++ b/ps_emailsmanager.php
@@ -776,7 +776,13 @@ class Ps_EmailsManager extends Module
         // is being configured, load the default values
         if (is_null($userSettings) || $userSettings['name'] !== $settings['name']) {
             foreach ($settings['inputs'] as $param) {
-                $fieldsValue[$param['name']] = $param['default'];
+                 if (isset($param['lang']) && $param['lang'] == true) {
+                    foreach (Language::getLanguages(true) as $lang) {
+                        $fieldsValue[$param['name']][$lang['id_lang']] = isset($param['default'][$lang['iso_code']]) ? $param['default'][$lang['iso_code']] : '';
+                    }
+                } else {
+                    $fieldsValue[$param['name']] = $param['default'];
+                }
             }
         } else {
             // The merchant wants to edit the currently installed template so we load his settings


### PR DESCRIPTION
Please see this modification to add support of multilang fields in template settings form.

Tested on ps 1.6 version, with en, fr and es languages installed

In the settings.json simply write for example : 
[...]
{
      "type": "text",
      "name": "custom_text",
      **"default": {
        "en" : "My custom text !"
      },**
      "required": false,
      **"lang": true,**
      "label": {
        "en": "Custom text",
        "fr": "Texte personnalisé"
      },
      "desc": {
        "en": "...",
        "fr": "..."
      }
    }
[...]

kind regards

![custom lang text](https://cloud.githubusercontent.com/assets/17274434/23546843/b28fe516-0001-11e7-8a72-9214db2f58e0.png)